### PR TITLE
Fix config paths for last OctoberCMS build

### DIFF
--- a/controllers/galleries/config_form.yaml
+++ b/controllers/galleries/config_form.yaml
@@ -6,7 +6,7 @@
 name: raviraj.rjgallery::lang.idgallery.title
 
 # Model Form Field configuration
-form: @/plugins/raviraj/rjgallery/models/gallery/fields.yaml
+form: $/raviraj/rjgallery/models/gallery/fields.yaml
 
 # Model Class name
 modelClass: Raviraj\Rjgallery\Models\Gallery

--- a/controllers/galleries/config_list.yaml
+++ b/controllers/galleries/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 # Model List Column configuration
-list: @/plugins/raviraj/rjgallery/models/gallery/columns.yaml
+list: $/raviraj/rjgallery/models/gallery/columns.yaml
 
 # Model Class name
 modelClass: Raviraj\Rjgallery\Models\Gallery

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -19,3 +19,5 @@
 - Add CS locale
 1.1.0:
 - Fix deleting galleries
+1.1.1:
+- Fix config path for OctoberCMS build 324


### PR DESCRIPTION
Fix config paths. Symbol `@` is not more compatible:

![snimek obrazovky 2016-04-11 v 18 02 06](https://cloud.githubusercontent.com/assets/374917/14433781/f3cb7132-000f-11e6-8e09-16ad46d0ffe9.png)
